### PR TITLE
Fix episode fetching to avoid extra skeleton

### DIFF
--- a/src/app/episodes/[id]/[slug]/page.tsx
+++ b/src/app/episodes/[id]/[slug]/page.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
-  const episodes = await getEpisodes();
+  const { episodes } = await getEpisodes();
   return episodes ? episodes.map((episode) => ({
     slug: episode.title.replaceAll(" ", "-").toLowerCase(),
     id: episode.id.toString()
@@ -16,7 +16,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params
 }: {
-  params: { slug: string; id: number};
+  params: { slug: string; id: number };
 }) {
   const episode = await getEpisode(params.id);
   if (!episode) {
@@ -61,17 +61,17 @@ export default async function Episode({ params }: { params: { slug: string; id: 
     <div className={styles.episode}>
       <Image src="/fea_logo.png" alt="Frontend Army Logo" width={200} height={200} />
       <div className={styles.episodeContent}>
-      <h1 className={styles.episodeName}>{episode.title}</h1>
-      <p className={styles.episodeDescription}>{episode.description}</p>
-      <div className={styles.episodeLinks}>
-      <Link className={styles.episodeLink} href={episode.youtube_url} target="_blank" rel="noopener noreferrer">
-        Watch on YouTube
-      </Link>
-      <Link className={styles.episodeLink} href={episode.spotify_url} target="_blank" rel="noopener noreferrer">
-        Listen on Spotify
-      </Link>
+        <h1 className={styles.episodeName}>{episode.title}</h1>
+        <p className={styles.episodeDescription}>{episode.description}</p>
+        <div className={styles.episodeLinks}>
+          <Link className={styles.episodeLink} href={episode.youtube_url} target="_blank" rel="noopener noreferrer">
+            Watch on YouTube
+          </Link>
+          <Link className={styles.episodeLink} href={episode.spotify_url} target="_blank" rel="noopener noreferrer">
+            Listen on Spotify
+          </Link>
+        </div>
       </div>
-    </div>
 
     </div>
   );

--- a/src/app/episodes/components/EpisodesList/index.tsx
+++ b/src/app/episodes/components/EpisodesList/index.tsx
@@ -12,7 +12,7 @@ interface Props {
   initialEpisodes: Array<Episode>
 }
 
-export const EpisodesList: React.FC<Props> = ({initialEpisodes}) => {
+export const EpisodesList: React.FC<Props> = ({ initialEpisodes }) => {
   const [episodes, setEpisodes] = useState<Array<Episode>>(initialEpisodes);
   const [page, setPage] = useState(0);
   const [reachedEnd, setReachedEnd] = useState(false);
@@ -21,15 +21,14 @@ export const EpisodesList: React.FC<Props> = ({initialEpisodes}) => {
 
   useEffect(() => {
     const loadMoreEpisodes = async () => {
-      const episodesPage = await getEpisodes(9, page + 1);
+      const { episodes: episodesPage, hasNextPage } = await getEpisodes(9, page + 1);
       setPage((currentPage) => currentPage + 1);
       if (episodesPage?.length) {
         setEpisodes((currentEpisodes) => ([
           ...currentEpisodes,
           ...episodesPage
         ]));
-      } else {
-        setReachedEnd(true);
+        setReachedEnd(!hasNextPage);
       }
     }
 

--- a/src/app/episodes/page.tsx
+++ b/src/app/episodes/page.tsx
@@ -14,18 +14,18 @@ export const metadata = {
 };
 
 export default async function Episodes() {
-  const episodes = await getEpisodes(9, 0);
+  const { episodes } = await getEpisodes(9, 0);
   return (
     <>
-    <FloatingHeader />
-    <DotBackground />
-    <main className={styles.episodesContainer}>
-      <SectionTitle className="text-center">Todos los capitulos</SectionTitle>
-      <UpcomingEpisodeCountdown />
-      {episodes && (
-        <EpisodesList initialEpisodes={episodes} />
-      )}
-    </main>
+      <FloatingHeader />
+      <DotBackground />
+      <main className={styles.episodesContainer}>
+        <SectionTitle className="text-center">Todos los capitulos</SectionTitle>
+        <UpcomingEpisodeCountdown />
+        {episodes && (
+          <EpisodesList initialEpisodes={episodes} />
+        )}
+      </main>
     </>
   );
 };

--- a/src/app/home/components/EpisodesSection/index.tsx
+++ b/src/app/home/components/EpisodesSection/index.tsx
@@ -7,7 +7,7 @@ import { SectionTitle } from "@/components/SectionTitle";
 export const revalidate = 3600;
 
 export const EpisodesSection: React.FC = async () => {
-  const episodes = await getEpisodes(6, 0);
+  const { episodes } = await getEpisodes(6, 0);
   return (
     <section id="episodes" className={`flex flex-col items-center gap-20 ${styles.episodesSection}`}>
       <SectionTitle>Podcast</SectionTitle>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,9 +1,9 @@
 import { getEpisodes } from '@/services/episodes'
 import { fetchPosts } from './api/blogpost'
- 
+
 export default async function sitemap() {
-  const [episodes, posts] = await Promise.all([
-    getEpisodes(),  
+  const [{ episodes }, posts] = await Promise.all([
+    getEpisodes(),
     fetchPosts(),
   ]);
 

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -71,7 +71,7 @@ export const Footer: React.FC = () => {
           </div>
           <div className={styles.footerStreamingSession}>
             <h5 className={styles.footerScheduleTitle}>
-              Miércoles: Charlas & Podcast
+              Miércoles: Entrevistas, Noticias y Podcast
             </h5>
             <p className={styles.footerSchedule}>
               <span className={styles.footerScheduleEntry}>

--- a/src/services/episodes.ts
+++ b/src/services/episodes.ts
@@ -8,7 +8,7 @@ export async function getEpisodes(size?: number, pageNumber?: number) {
   if (size && pageNumber !== undefined) {
     episodes = await supabase
       .from("episodes")
-      .select("*")
+      .select("*", { count: "exact" })
       .order("id", { ascending: false })
       .range(pageNumber * size, pageNumber * size + size - 1)
       .returns<Array<Episode>>();
@@ -20,7 +20,10 @@ export async function getEpisodes(size?: number, pageNumber?: number) {
       .returns<Array<Episode>>();
   }
 
-  return episodes.data;
+  return {
+    episodes: episodes.data,
+    hasNextPage: size && pageNumber !== undefined && episodes.count ? episodes.count > (pageNumber + 1) * size : false
+  };
 }
 
 export async function getEpisode(id: number) {


### PR DESCRIPTION
- Updated `getEpisodes` to return an object containing episodes and pagination info.
- Adjusted related components to destructure the new response format.

Fixes #30
Fixes #27